### PR TITLE
Bumping protobuf version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --update \
 
 # Build protobuf against configured revision
 #
-ENV PROTOBUF_REVISION 3.7.1
+ENV PROTOBUF_REVISION 3.13.0
 RUN curl -sLO https://github.com/google/protobuf/releases/download/v${PROTOBUF_REVISION}/protoc-${PROTOBUF_REVISION}-linux-x86_64.zip \
   && unzip protoc-${PROTOBUF_REVISION}-linux-x86_64.zip -d ./usr/local \
   && chmod +x /usr/local/bin/protoc \


### PR DESCRIPTION
Protobuffer version from 3.7.1 to 3.13.0 to support v2 Go protobuf API
ref.:https://github.com/grupozap/squad-growth/issues/1099